### PR TITLE
Enable local service, add levels

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -11,7 +11,11 @@ async function main () {
     console.log('game state changed:', patches);
     console.log('game state:', game.state);
     console.log('Poor Yorick:', game.state.local.users[name]);
-    // this.fabric.applyPatches(patches);
+    game.fabric.applyPatches(patches);
+  });
+
+  game.on('message', function (msg) {
+    console.log('[MESSAGE]', msg);
   });
 
   // when the game starts, add player and emulate some behavior

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -29,6 +29,12 @@ function Entity (entity) {
   return this;
 }
 
+Object.defineProperty(Entity.prototype, 'level', {
+  get: function level () {
+    return Math.floor(Math.log(this.experience));
+  }
+});
+
 Object.defineProperty(Entity.prototype, 'strength', {
   get: function strength () {
     return this.stats.strength;

--- a/lib/idlerpg.js
+++ b/lib/idlerpg.js
@@ -21,6 +21,7 @@ const ENCOUNTER_CHANCE = 0.05;
  */
 function IdleRPG (config) {
   this.config = Object.assign({
+    channel: 'idlerpg',
     interval: TICK_INTERVAL,
     PER_TICK_CAPITAL: PER_TICK_CAPITAL,
     PER_TICK_EXPERIENCE: PER_TICK_EXPERIENCE
@@ -67,7 +68,7 @@ IdleRPG.prototype.start = async function () {
     try {
       rpg.tick();
     } catch (E) {
-      console.error(E);
+      console.error('error ticking:', E);
     }
   }, this.config.interval);
 
@@ -195,8 +196,19 @@ IdleRPG.prototype.reward = async function (player) {
     Object.assign(player, instance);
   }
 
+  // snapshot initial state
+  let prior = new Entity(player);
+
+  // primary updates
   player.wealth = (player.wealth || 0) + PER_TICK_CAPITAL;
   player.experience = (player.experience || 0) + PER_TICK_EXPERIENCE;
+
+  // sample the contents
+  let sample = new Entity(player);
+
+  if (sample.level > prior.level) {
+    rpg.announce(`${player.name} has reached level ${sample.level}!`);
+  }
 
   manager.applyPatch(rpg.state, [
     { op: 'replace', path: `/${player.id}`, value: player }
@@ -394,12 +406,11 @@ IdleRPG.prototype._registerUser = async function registerUser (user) {
 
   let id = parts.join('/');
   let prior = await rpg._getProfile(id);
+  let instance = Object.assign({}, prior, user);
 
   if (!rpg.state[parts[0]]) {
-    rpg._registerService({ name: parts[0] });
+    await rpg._registerService({ name: parts[0] });
   }
-
-  let instance = Object.assign({}, prior, user);
 
   try {
     let raw = JSON.parse(JSON.stringify(instance));


### PR DESCRIPTION
This enables the simple example (via `node examples/simple.js`) through a local service, and now also calculates levels based on a simple `log(exp)` function.